### PR TITLE
add typescript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.3",
   "description": "personal pronoun helper",
   "main": "src/index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "test": "node test/",
     "dist": "browserify src -o dist/index.js --standalone pronouns",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": [
+            "es6",
+            "dom"
+        ],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "esModuleInterop": true,
+        "noEmit": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "types/index.d.ts",
+    ]
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,53 @@
+export type Pronoun = [subject: string, object: string, determiner: string, possessive: string, reflexive: string];
+export type PartialPronoun = [string, string?, string?, string?, string?];
+
+export interface Pronouns {
+  pronouns: Pronoun[];
+  examples: Pronoun[];
+
+  subject: string;
+  object: string;
+  determiner: string;
+  possessive: string;
+  reflexive: string;
+
+  sub: string;
+  obj: string;
+  det: string;
+  pos: string;
+  ref: string;
+
+  constructor(input: string): void;
+
+  generateForms(i: number): void;
+  generateExamples(): void;
+  toString(): string;
+  toUrl(): string;
+  add(input: string): void;
+}
+
+export default function (input: string, log?: boolean): Pronouns;
+
+export function complete(input: string): string[];
+
+export const table: Pronoun[];
+
+interface Util {
+  logging: boolean;
+  tableFrontFilter: (q: PartialPronoun, table: Pronoun[]) => Pronoun[];
+  tableEndFilter: (q: PartialPronoun, table: Pronoun[]) => Pronoun[];
+  tableLookup: (q: PartialPronoun, table: Pronoun[]) => Pronoun | undefined;
+  shortestUnambiguousForwardPath: (table: Pronoun[], row: PartialPronoun) => PartialPronoun;
+  shortestUnambiguousEllipsesPath: (table: Pronoun[], row: PartialPronoun) => PartialPronoun;
+  shortestUnambiguousPath: (table: Pronoun[], row: PartialPronoun) => PartialPronoun;
+  abbreviate: (table: Pronoun[]) => string[][];
+  sanitizeSet: (p: PartialPronoun[], table: Pronoun[]) => Pronoun[];
+  expandString: (str: string, table: Pronoun[]) => Pronoun[];
+  arrFormat: <T extends any>(x: T | T[]) => T[];
+  capitalize: (str: string) => string;
+  rowsEqual: (a: PartialPronoun, b: Pronoun) => boolean;
+}
+
+export const util: Util;
+
+export const abbreviated: string[][];


### PR DESCRIPTION
As promised the PR with the type declarations, to close #10.

**Notes** 

- I tried to run the tests, but they fail because of non-typing-related issues. (The example files set pronouns in bold (`**They** went to the park`), but the examples they are compared against don't (`They went to the park`), so they always fail.)
- I am not sure about the typings for the complete() function, as no matter what string I fed it, I always got an Unrecognized pronoun warning. I tried everything from "she", "she/her", "she/her/her/hers/herself" to "she or he" and since the structure of the string isn't documented I couldn't fully test the function. It seems to always return a string array though so that's what I typed it as.